### PR TITLE
RNMT-3515 Close toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Additions
+- Toolbar can now be closed again [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515)
 - Add dark mode for iOS [RNMT-3526](https://outsystemsrd.atlassian.net/browse/RNMT-3526)
 
 ## [3.0.0-OS]

--- a/Classes/Toolbar/FLEXExplorerToolbar.m
+++ b/Classes/Toolbar/FLEXExplorerToolbar.m
@@ -84,7 +84,7 @@
         self.selectedViewDescriptionLabel.font = [[self class] descriptionLabelFont];
         [self.selectedViewDescriptionSafeAreaContainer addSubview:self.selectedViewDescriptionLabel];
         
-        self.toolbarItems = @[_globalsItem];
+        self.toolbarItems = @[_globalsItem, _closeItem];
     }
         
     return self;


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
Now that there will be a way to manually activate FLEX, re-adding the close button is back on the table.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
References https://outsystemsrd.atlassian.net/browse/RNMT-3515

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests
Manual testing

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly