### PR TITLE
RNMT-3515 Resize toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Fixed toolbar size being too small on some devices [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515)
 
 ## [3.0.0-OS1]
 ### Additions

--- a/Classes/ExplorerInterface/FLEXExplorerViewController.m
+++ b/Classes/ExplorerInterface/FLEXExplorerViewController.m
@@ -102,7 +102,7 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
     CGFloat toolbarOriginY = toolbarOriginYDefault ? [toolbarOriginYDefault doubleValue] : 100;
 
     CGRect safeArea = [self viewSafeArea];
-    CGSize toolbarSize = [self.explorerToolbar sizeThatFits:CGSizeMake(70, CGRectGetHeight(safeArea))];
+    CGSize toolbarSize = [self.explorerToolbar sizeThatFits:CGSizeMake(128, CGRectGetHeight(safeArea))];
     [self updateToolbarPositionWithUnconstrainedFrame:CGRectMake(CGRectGetMinX(safeArea), toolbarOriginY, toolbarSize.width, toolbarSize.height)];
     self.explorerToolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin;
     [self.view addSubview:self.explorerToolbar];
@@ -709,7 +709,7 @@ typedef NS_ENUM(NSUInteger, FLEXExplorerMode) {
   }
 
   CGRect safeArea = [self viewSafeArea];
-  CGSize toolbarSize = [self.explorerToolbar sizeThatFits:CGSizeMake(70, CGRectGetHeight(safeArea))];
+  CGSize toolbarSize = [self.explorerToolbar sizeThatFits:CGSizeMake(128, CGRectGetHeight(safeArea))];
   [self updateToolbarPositionWithUnconstrainedFrame:CGRectMake(CGRectGetMinX(self.explorerToolbar.frame), CGRectGetMinY(self.explorerToolbar.frame), toolbarSize.width, toolbarSize.height)];
 }
 #endif


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
With the re-addition of the close button from #5, the toolbar size was clipping its elements on some devices. This new width better accommodates the extra button.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
References https://outsystemsrd.atlassian.net/browse/RNMT-3515

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests
Manual testing

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly