### PR TITLE
RNMT-4439 Add support for iOS 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Additions
+- Add support for iOS 14 [RNMT-4439](https://outsystemsrd.atlassian.net/browse/RNMT-4439)
 
 ## [3.0.0-OS3]
 ### Fixes

--- a/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
+++ b/Classes/Network/PonyDebugger/FLEXNetworkObserver.m
@@ -279,13 +279,20 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask delegate:(id <NSU
         // In iOS 7 resume lives in __NSCFLocalSessionTask
         // In iOS 8 resume lives in NSURLSessionTask
         // In iOS 9 resume lives in __NSCFURLSessionTask
+        // In iOS 14 resume lives in NSURLSessionTask
         Class class = Nil;
-        if (![[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)]) {
-            class = NSClassFromString([@[@"__", @"NSC", @"FLocalS", @"ession", @"Task"] componentsJoinedByString:@""]);
-        } else if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion < 9) {
-            class = [NSURLSessionTask class];
+        if (![NSProcessInfo.processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
+            // iOS ... 7
+            class = NSClassFromString(@"__NSCFLocalSessionTask");
         } else {
-            class = NSClassFromString([@[@"__", @"NSC", @"FURLS", @"ession", @"Task"] componentsJoinedByString:@""]);
+            NSInteger majorVersion = NSProcessInfo.processInfo.operatingSystemVersion.majorVersion;
+            if (majorVersion < 9 || majorVersion >= 14) {
+                // iOS 8 or iOS 14+
+                class = [NSURLSessionTask class];
+            } else {
+                // iOS 9 ... 13
+                class = NSClassFromString(@"__NSCFURLSessionTask");
+            }
         }
         SEL selector = @selector(resume);
         SEL swizzledSelector = [FLEXUtility swizzledSelectorForSelector:selector];


### PR DESCRIPTION
This PR introduces the required changes to support iOS 14.

I tried to upgrade our branch with the latest version of upstream but it was causing builds to fail. After some hours dealing with the conflicts and having the FLEX being built with success, I was still unable to build applications successfully. Then, I decided to just cherry pick the changes to support iOS 14, since the latest stable version doesn't have the support for iOS 14.