### PR TITLE
RDMR-1423 Raise the iOS deployment target to 16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.22.10+2.0.0]
+### Fixes
+- **BREAKING:** Raise the iOS deployment target from 9.0 to 16.0. Xcode 27 rejects pods below the SDK's minimum supported deployment target, which turned the inherited 9.0 value into a build error [RDMR-1423](https://outsystemsrd.atlassian.net/browse/RDMR-1423)
+
 ## [5.22.10+1.0.0]
 ### Changes
 - Toolbar is smaller [RNMT-3280](https://outsystemsrd.atlassian.net/browse/RNMT-3280) [RNMT-3515](https://outsystemsrd.atlassian.net/browse/RNMT-3515) [RNMT-5718](https://outsystemsrd.atlassian.net/browse/RNMT-5718)
@@ -19,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Remove string references to FLEX [RNMT-3597](https://outsystemsrd.atlassian.net/browse/RNMT-3597) [RNMT-5718](https://outsystemsrd.atlassian.net/browse/RNMT-5718)
 
-[Unreleased]: https://github.com/OutSystems/FLEX/compare/5.22.10+1.0.0...outsystems
+[Unreleased]: https://github.com/OutSystems/FLEX/compare/5.22.10+2.0.0...outsystems
+[5.22.10+2.0.0]: https://github.com/OutSystems/FLEX/compare/5.22.10+1.0.0...5.22.10+2.0.0
 [5.22.10+1.0.0]: https://github.com/OutSystems/FLEX/compare/5.22.10...5.22.10+1.0.0

--- a/FLEX.podspec
+++ b/FLEX.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
   spec.license          = { :type => "BSD", :file => "LICENSE" }
   spec.author           = { "Tanner Bennett" => "tannerbennett@me.com" }
   spec.social_media_url = "https://twitter.com/NSExceptional"
-  spec.platform         = :ios, "9.0"
+  spec.platform         = :ios, "16.0"
   spec.source           = { :git => "https://github.com/OutSystems/FLEX.git", :tag => "#{spec.version}" }
   spec.source_files     = "Classes/**/*.{h,c,m,mm}"
   spec.exclude_files    = "Classes/Headers/*.{h,c,m,mm}"

--- a/FLEX.podspec
+++ b/FLEX.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = "FLEX"
-  spec.version          = "5.22.10+1.0.0"
+  spec.version          = "5.22.10+2.0.0"
   spec.summary          = "A set of in-app debugging and exploration tools for iOS"
   spec.description      = <<-DESC
                         - Inspect and modify views in the hierarchy.


### PR DESCRIPTION
## Description
<!--- Provide a small description of the problem in hands -->
The podspec still declared `spec.platform = :ios, "9.0"`, inherited from upstream. Xcode 27 raises the minimum supported deployment target for the iOS Simulator SDK from 12.0 to 15.0, and a pod below that range is now a build error rather than a warning, so any app embedding this pod fails to build.

CocoaPods keeps the podspec value on the pod target, so a consuming Podfile cannot raise it — the fix has to happen here. The new value, 16.0, matches the minimum supported iOS version of the OutSystems native shell that consumes this pod.

This is a breaking change for any consumer targeting below iOS 16.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RDMR-1423

<!--- Why is this change required? What problem does it solve? -->
Without it, debug builds of the native shell fail on Xcode 27:

```
Pods/Pods.xcodeproj: error: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET'
is set to 9.0, but the range of supported deployment target versions is 15.0 to 27.0.x.
(in target 'FLEX' from project 'Pods')
```

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [x] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Tests
`pod spec lint` passes validation.

Verified end to end against a native shell app generated from the template, with this branch consumed via `:path`:

| | Before (`5.22.10+1.0.0`) | After (this branch) |
|---|---|---|
| FLEX `IPHONEOS_DEPLOYMENT_TARGET` | 9.0 | 16.0 |
| Xcode 27 build | `** BUILD FAILED **` | `** BUILD SUCCEEDED **` |
| Deployment-target diagnostics | 1 error | none |

CocoaPods resolved it as `Installing FLEX 5.22.10+2.0.0`. The app installs and launches on an iOS simulator with no crashes and no `CDV`/cordova runtime errors; it renders the shell's `error.html`, which is expected without a MABS-injected app payload (`hostname` and `DefaultApplicationURL` are empty in the template).

Builds on Xcode 26.6 were also confirmed working before and after the change, so this does not regress the currently supported toolchain.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
